### PR TITLE
Prepare for a breaking change in the Rust compiler.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -49,7 +49,7 @@ impl<'a, A: Allocator + Clone> Context<'a, A> {
         self.drain_comments_before(line_index + 1)
     }
 
-    pub fn peek_comments_before(&self, line_index: usize) -> impl Iterator<Item = &'a Comment> {
+    pub fn peek_comments_before(&self, line_index: usize) -> impl Iterator<Item = &'_ Comment> {
         self.comments
             .range(
                 ..self


### PR DESCRIPTION
The soundness fix in rust-lang/rust#115008 will cause schemat to break, even though it is not unsound. The missing bound is very hard to abuse, but still a soundness hole in our type system.

It will likely take 12 weeks before a stable compiler with the soundness fix is shipped.